### PR TITLE
Exposed setters for submission success/fail blocks.

### DIFF
--- a/Demo/librato-iOS Demo/LibratoDemoAppDelegate.m
+++ b/Demo/librato-iOS Demo/LibratoDemoAppDelegate.m
@@ -28,6 +28,7 @@
     [eventTracker notificationExample];
     [eventTracker metricCreationHelpersExample];
     [eventTracker customUAExample];
+    [eventTracker submissionBlocksExample];
     
     return YES;
 }

--- a/Demo/librato-iOS Demo/LibratoDemoEventTracker.h
+++ b/Demo/librato-iOS Demo/LibratoDemoEventTracker.h
@@ -25,5 +25,6 @@
 - (void)notificationExample;
 - (void)customUAExample;
 - (void)metricCreationHelpersExample;
+- (void)submissionBlocksExample;
 
 @end

--- a/Demo/librato-iOS Demo/LibratoDemoEventTracker.m
+++ b/Demo/librato-iOS Demo/LibratoDemoEventTracker.m
@@ -185,6 +185,24 @@ NSString *const libratoPrefix = @"demo";
 }
 
 
+- (void)submissionBlocksExample
+{
+    Librato *libratoInstance = LibratoDemoEventTracker.sharedInstance;
+    
+    [libratoInstance setSubmitSuccessBlock:^(NSDictionary *JSON, NSUInteger code) {
+        if (code == 200) {
+            NSLog(@"Successful submission. Response JSON is: %@", JSON);
+        }
+    }];
+    
+    [libratoInstance setSubmitFailureBlock:^(NSError *error, NSDictionary *JSON) {
+        NSLog(@"Error submitting metric: %@", error);
+    }];
+    
+    [libratoInstance submit:[LibratoMetric metricNamed:@"callbacks.test" valued:@123]];
+}
+
+
 #pragma mark - Helpers
 - (NSNumber *)randomNumber
 {

--- a/README.md
+++ b/README.md
@@ -105,6 +105,32 @@ The `LibratoGroupMetric` automatically generates the count, sum, minimum, maximu
 
 There's an optional but highly-recommended prefix you can set which will automatically be added to all metric names. This is a great way to isolate data or quickly filter metrics.
 
+# Monitoring Submission Success or Failure
+
+You can set a blocks to handle the success and failure cases for metric submission. These are referenced when the submission calls back so sporadically setting or `nil`-ling the blocks may lead to unexpected results.
+
+```objective-c
+Librato *librato = [Librato.alloc initWithEmail:@"user@somewhere.com" apiKey:@"abc123..." prefix:@""];
+[libratoInstance setSubmitSuccessBlock:^(NSDictionary *JSON, NSUInteger code) {
+    if (code == 200) {
+        NSLog(@"Successful submission. Response JSON is: %@", JSON);
+    }
+}];
+
+[libratoInstance setSubmitFailureBlock:^(NSError *error, NSDictionary *JSON) {
+    NSLog(@"Error submitting metric: %@", error);
+}];
+
+[libratoInstance submit:[LibratoMetric metricNamed:@"callbacks.test" valued:@123]];
+```
+
+If you want to disable the blocks, simply set them to `nil`.
+
+```objective-c
+[libratoInstance setSubmitSuccessBlock:nil];
+[libratoInstance setSubmitFailureBlock:nil];
+```
+
 # Offline Metric Gathering
 
 If the device loses network availability all new metrics are cached until the network (WiFi or cell) becomes again available.

--- a/librato-iOS/Classes/LibratoClient.h
+++ b/librato-iOS/Classes/LibratoClient.h
@@ -25,11 +25,14 @@ typedef void (^ClientFailureBlock)(NSError *error, NSDictionary *JSON);
 @property (nonatomic, strong) NSString *persistence;
 @property (nonatomic, strong) id<LibratoPersister> persister;
 @property (nonatomic, strong) LibratoQueue *queue;
+@property (nonatomic, copy) ClientSuccessBlock submitSuccessBlock;
+@property (nonatomic, copy) ClientFailureBlock submitFailureBlock;
 
 - (void)authenticateEmail:(NSString *)emailAddress APIKey:(NSString *)apiKey;
 - (void)getMetric:(NSString *)name options:(NSDictionary *)options;
 - (void)getMeasurements:(NSString *)named options:(NSDictionary *)options;
 - (NSDictionary *)metrics;
+- (void)sendPayload:(NSDictionary *)payload;
 - (void)sendPayload:(NSDictionary *)payload withSuccess:(ClientSuccessBlock)success orFailure:(ClientFailureBlock)failure;
 - (void)submit:(id)metrics;
 - (void)updateMetricsNamed:(NSString *)name options:(NSDictionary *)options;

--- a/librato-iOS/Classes/LibratoClient.m
+++ b/librato-iOS/Classes/LibratoClient.m
@@ -219,6 +219,12 @@ NSString *APIKey;
 }
 
 
+- (void)sendPayload:(NSDictionary *)payload
+{
+    [self sendPayload:payload withSuccess:self.submitSuccessBlock orFailure:self.submitFailureBlock];
+}
+
+
 - (void)sendPayload:(NSDictionary *)payload withSuccess:(ClientSuccessBlock)success orFailure:(ClientFailureBlock)failure
 {
     [self setUser:email andToken:APIKey];

--- a/librato-iOS/Classes/LibratoDirectPersister.m
+++ b/librato-iOS/Classes/LibratoDirectPersister.m
@@ -30,11 +30,7 @@
     }
 
     [requests enumerateObjectsUsingBlock:^(NSDictionary *metricData, NSUInteger idx, BOOL *stop) {
-        [client sendPayload:metricData withSuccess:^(NSDictionary *JSON, NSUInteger code) {
-            // TODO: Hook for success block
-        } orFailure:^(NSError *error, NSDictionary *JSON) {
-            // TODO: Hook for failure block
-        }];
+        [client sendPayload:metricData];
     }];
     
     return YES;

--- a/librato-iOS/Librato.h
+++ b/librato-iOS/Librato.h
@@ -11,6 +11,7 @@
 #import "LibratoGaugeMetric.h"
 #import "LibratoMetric.h"
 #import "LibratoPersister.h"
+#import "LibratoClient.h"
 
 
 extern NSString *const LIBRATO_LOCALIZABLE;
@@ -48,7 +49,8 @@ typedef void (^LibratoNotificationContext)(NSNotification *notification);
 - (void)getMeasurements:(NSString *)named options:(NSDictionary *)options;
 - (void)updateMetricsNamed:(NSString *)name options:(NSDictionary *)options;
 - (void)updateMetrics:(NSDictionary *)metrics;
-
+- (void)setSubmitSuccessBlock:(ClientSuccessBlock)successBlock;
+- (void)setSubmitFailureBlock:(ClientFailureBlock)failureBlock;
 - (NSArray *)groupNamed:(NSString *)name valued:(NSDictionary *)values;
 - (NSArray *)groupNamed:(NSString *)name context:(LibratoMetricContext)context;
 - (id)listenForNotification:(NSString *)named context:(LibratoNotificationContext)context;

--- a/librato-iOS/Librato.m
+++ b/librato-iOS/Librato.m
@@ -130,6 +130,18 @@ NSString *const LIBRATO_LOCALIZABLE = @"Librato-Localizable";
 }
 
 
+- (void)setSubmitSuccessBlock:(ClientSuccessBlock)successBlock
+{
+    self.client.submitSuccessBlock = successBlock;
+}
+
+
+- (void)setSubmitFailureBlock:(ClientFailureBlock)failureBlock
+{
+    self.client.submitFailureBlock = failureBlock;
+}
+
+
 #pragma mark - Helpers
 - (NSArray *)groupNamed:(NSString *)name valued:(NSDictionary *)values
 {


### PR DESCRIPTION
Allows global handler for metric submission success or failure. 
