### PR TITLE
Autosubmit timer & prefer add:, not submit:

### DIFF
--- a/Demo/librato-iOS Demo/LibratoDemoEventTracker.m
+++ b/Demo/librato-iOS Demo/LibratoDemoEventTracker.m
@@ -51,28 +51,28 @@ NSString *const libratoPrefix = @"demo";
     LibratoMetric *simpleMetric = [LibratoMetric metricNamed:@"works" valued:self.randomNumber options:@{@"source": @"demo app"}];
     simpleMetric.measureTime = [NSDate dateWithTimeIntervalSinceNow:-(60*5)];
     
-    [LibratoDemoEventTracker.sharedInstance submit:simpleMetric];
+    [LibratoDemoEventTracker.sharedInstance add:simpleMetric];
 }
 
 
 /*
- Creates two different metrics but submits them simultaneously
+ Creates two different metrics but adds them simultaneously
 */
 - (void)multipleMetricSubmissionExample
 {
     LibratoMetric *memoryMetric  = [LibratoMetric metricNamed:@"memory.available" valued:self.randomNumber options:nil];
     LibratoMetric *storageMetric = [LibratoMetric metricNamed:@"storage.available" valued:self.randomNumber options:nil];
     
-    [LibratoDemoEventTracker.sharedInstance submit:@[memoryMetric, storageMetric]];
+    [LibratoDemoEventTracker.sharedInstance add:@[memoryMetric, storageMetric]];
 }
 
 
 /*
- Creates and auto-submits two counter metrics: "meaning" and "plutonium", the latter using an NSDictionary to set the value and source simultaneously
+ Creates two counter metrics: "meaning" and "plutonium", the latter using an NSDictionary to set the value and source simultaneously
 */
 - (void)dictionaryCreationExample
 {
-    [LibratoDemoEventTracker.sharedInstance submit:@{@"meaning": self.randomNumber, @"plutonium": @{@"value": @238, @"source": @"Russia, with love"}}];
+    [LibratoDemoEventTracker.sharedInstance add:@{@"meaning": self.randomNumber, @"plutonium": @{@"value": @238, @"source": @"Russia, with love"}}];
 }
 
 
@@ -84,7 +84,7 @@ NSString *const libratoPrefix = @"demo";
  The group prefix is the first argument and is joined to each metric named with a period.
  The dictionary's key value is the metric name as an NSString and the value is an NSNumber value.
  
- If the group is named "foo" and the first metric is named "bar" it will be submitted with the name "foo.bar"
+ If the group is named "foo" and the first metric is named "bar" it metric's submitted name will be "foo.bar"
 */
 - (void)groupDictionaryExample
 {
@@ -94,7 +94,7 @@ NSString *const libratoPrefix = @"demo";
                                 @"friends": @172
                                 };
     NSArray *metrics = [LibratoDemoEventTracker.sharedInstance groupNamed:@"user" valued:valueDict];
-    [LibratoDemoEventTracker.sharedInstance submit:metrics];
+    [LibratoDemoEventTracker.sharedInstance add:metrics];
 }
 
 
@@ -107,7 +107,7 @@ NSString *const libratoPrefix = @"demo";
         LibratoMetric *logins = [LibratoMetric metricNamed:@"logins" valued:@12 options:nil];
         LibratoMetric *logouts = [LibratoMetric metricNamed:@"logouts" valued:@7 options:nil];
         LibratoMetric *timeouts = [LibratoMetric metricNamed:@"timeouts" valued:@5 options:nil];
-        [l submit:@[logins, logouts, timeouts]];
+        [l add:@[logins, logouts, timeouts]];
     }];
 }
 
@@ -124,7 +124,7 @@ NSString *const libratoPrefix = @"demo";
         LibratoMetric *useName = [LibratoMetric metricNamed:notification.name valued:@100 options:nil];
         LibratoMetric *useInfo = [LibratoMetric metricNamed:notification.userInfo[@"name"] valued:notification.userInfo[@"value"] options:notification.userInfo];
         
-        [weakDemo submit:@[useName, useInfo]];
+        [weakDemo add:@[useName, useInfo]];
     }];
     
     [NSNotificationCenter.defaultCenter postNotificationName:@"state.sleeping" object:nil userInfo:@{
@@ -138,7 +138,7 @@ NSString *const libratoPrefix = @"demo";
 
 
 /*
- Creates a series of counter measurements and submits them as a gague metric
+ Creates a series of counter measurements and adds them as a gague metric
 */
 - (void)gaugeMetricExample
 {
@@ -154,7 +154,7 @@ NSString *const libratoPrefix = @"demo";
     NSArray *bagels = @[metric1, metric2, metric3, metric4, metric5, metric6, metric7, metric8];
     LibratoGaugeMetric *bagelGuage = [LibratoGaugeMetric metricNamed:@"bagel_guage" measurements:bagels];
     
-    [LibratoDemoEventTracker.sharedInstance submit:bagelGuage];
+    [LibratoDemoEventTracker.sharedInstance add:bagelGuage];
 }
 
 
@@ -167,7 +167,7 @@ NSString *const libratoPrefix = @"demo";
     Librato *l = LibratoDemoEventTracker.sharedInstance;
     l.customUserAgent = @"Demo UA";
     
-    [l submit:@{@"ua.custom.instances": @1}];
+    [l add:@{@"ua.custom.instances": @1}];
 }
 
 
@@ -181,7 +181,7 @@ NSString *const libratoPrefix = @"demo";
     LibratoMetric *explicit = [LibratoMetric metricNamed:@"explicit" valued:@100 source:@"demo" measureTime:NSDate.date];
     LibratoMetric *custom = [LibratoMetric metricNamed:@"custom" valued:@50 options:@{@"source": @"demo"}];
     
-    [LibratoDemoEventTracker.sharedInstance submit:@[basic, explicit, custom]];
+    [LibratoDemoEventTracker.sharedInstance add:@[basic, explicit, custom]];
 }
 
 
@@ -199,7 +199,7 @@ NSString *const libratoPrefix = @"demo";
         NSLog(@"Error submitting metric: %@", error);
     }];
     
-    [libratoInstance submit:[LibratoMetric metricNamed:@"callbacks.test" valued:@123]];
+    [libratoInstance add:[LibratoMetric metricNamed:@"callbacks.test" valued:@123]];
 }
 
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ LibratoMetric *filesOpened = [LibratoMetric metricNamed:@"files.opened" valued:@
 // NOTE: The maximum age for any submitted metric is fifteen minutes, as dictated by Librato.
 filesOpened.measureTime = [NSDate.date dateByAddingTimeInterval:-10];
 
-[librato submit:filesOpened];
+[librato add:filesOpened];
 ```
 
 # Installation
@@ -75,10 +75,10 @@ metric.source = @"the internet";
 metric.measureTime = [NSDate.date dateByAddingTimeInterval:-(3600 * 24)]
 ```
 
-Optionally, you can create one or more counters inline with an NSDictionary when submitting.
+Optionally, you can create one or more counters inline with an NSDictionary when adding.
 
 ```objective-c
-[<some librato instance> submit:@{@"downloads": @13, @"plutonium": @{@"value": @238, @"source": @"Russia, with love"}}];
+[<some librato instance> add:@{@"downloads": @13, @"plutonium": @{@"value": @238, @"source": @"Russia, with love"}}];
 ```
 
 ### Grouping
@@ -101,6 +101,26 @@ LibratoGaugeMetric *bagelGuage = [LibratoGaugeMetric metricNamed:@"bagel_guage" 
 
 The `LibratoGroupMetric` automatically generates the count, sum, minimum, maximum and square values for the aggregate data for use in the reporting tool.
 
+# Submitting
+
+It is usually unnecessary to manually submit metrics. By default, `librato-iOS` will automatically submit anything that has been added to the queue every five seconds, if interent connectivity is available.
+
+Use the `autosubmitInterval` option when initializing a `LibratoQueue` instance to configure how often submissions should be triggered.
+
+This interval can be adjusted to any `NSTimeInterval` measurement but `librato-iOS` will only run the check for your timer once every second to avoid automated flooding.
+
+### Manual submission
+
+If you have a metrics you'd like to add to the queue and trigger an immediate submission you can use the `submit:` method. This accepts either metrics or a `nil` value.
+
+```objective-c
+// Adding metrics and immediately triggering a submission
+[<some librato-iOS instance> submit:metrics];
+
+// Passing nil will simply trigger the submission
+[<some librato-iOS instance> submit:nil];
+```
+
 # Custom Prefix
 
 There's an optional but highly-recommended prefix you can set which will automatically be added to all metric names. This is a great way to isolate data or quickly filter metrics.
@@ -121,7 +141,7 @@ Librato *librato = [Librato.alloc initWithEmail:@"user@somewhere.com" apiKey:@"a
     NSLog(@"Error submitting metric: %@", error);
 }];
 
-[libratoInstance submit:[LibratoMetric metricNamed:@"callbacks.test" valued:@123]];
+[libratoInstance add:[LibratoMetric metricNamed:@"callbacks.test" valued:@123]];
 ```
 
 If you want to disable the blocks, simply set them to `nil`.

--- a/librato-iOS/Classes/LibratoProcessor.h
+++ b/librato-iOS/Classes/LibratoProcessor.h
@@ -19,6 +19,7 @@ typedef void(^TimedExecutionBlock)(void);
 }
 
 @property (nonatomic) NSTimeInterval autosubmitInterval;
+@property (nonatomic, strong) NSTimer *autoSubmitTimer;
 @property (nonatomic) BOOL clearOnFailure;
 @property (nonatomic, strong) NSDate *createTime;
 @property (nonatomic, strong) NSMutableDictionary *queued;

--- a/librato-iOS/Librato.h
+++ b/librato-iOS/Librato.h
@@ -36,6 +36,7 @@ typedef void (^LibratoNotificationContext)(NSNotification *notification);
 - (instancetype)initWithEmail:(NSString *)email token:(NSString *)apiKey prefix:(NSString *)prefix;
 
 - (LibratoClient *)client;
+- (void)add:(id)metrics;
 - (void)authenticateEmail:(NSString *)emailAddress APIKey:(NSString *)apiKey;
 - (NSString *)APIEndpoint;
 - (void)setAPIEndpoint:(NSString *)APIEndpoint;

--- a/librato-iOS/Librato.m
+++ b/librato-iOS/Librato.m
@@ -235,7 +235,7 @@ NSString *const LIBRATO_LOCALIZABLE = @"Librato-Localizable";
     LibratoMetric *screenWidth = [LibratoMetric metricNamed:@"device.screen.width" valued:@(screen.width)];
     LibratoMetric *screenHeight = [LibratoMetric metricNamed:@"device.screen.height" valued:@(screen.height)];
     
-    [self submit:@[screenScale, screenCount, screenWidth, screenHeight]];
+    [self add:@[screenScale, screenCount, screenWidth, screenHeight]];
 }
 
 
@@ -249,7 +249,7 @@ NSString *const LIBRATO_LOCALIZABLE = @"Librato-Localizable";
         [versionLevels addObject:[LibratoMetric metricNamed:[NSString stringWithFormat:@"%@.%@", @"os.version", level] valued:value]];
     }];
     
-    [self submit:versionLevels];
+    [self add:versionLevels];
 }
 
 
@@ -263,17 +263,23 @@ NSString *const LIBRATO_LOCALIZABLE = @"Librato-Localizable";
         [versionLevels addObject:[LibratoMetric metricNamed:[NSString stringWithFormat:@"%@.%@", @"app", level] valued:value]];
     }];
     
-    [self submit:versionLevels];
+    [self add:versionLevels];
 }
 
 
 - (void)trackLibraryMetrics
 {
-    [self submit:[LibratoMetric metricNamed:@"librato-iOS.version" valued:@(LibratoVersion.version.floatValue)]];
+    [self add:[LibratoMetric metricNamed:@"librato-iOS.version" valued:@(LibratoVersion.version.floatValue)]];
 }
 
 
 #pragma mark - Submission
+- (void)add:(id)metrics
+{
+    [self.client.queue add:metrics];
+}
+
+
 - (void)submit:(id)metrics
 {
     [self.client submit:metrics];


### PR DESCRIPTION
Changed preferred handling of metrics from using `submit:` to force a submission to using `add:` to allow new auto-submit timer to come in and sweep up queued metrics. `submit:` left in non-deprecated as it's a valid option, just not preferred.
