### PR TITLE
Update pod project to silence warnings, stop ignoring Podfile.lock

### DIFF
--- a/Demo/.gitignore
+++ b/Demo/.gitignore
@@ -25,4 +25,3 @@ DerivedData
 
 # cocoapods
 Pods
-Podfile.lock

--- a/Demo/Podfile
+++ b/Demo/Podfile
@@ -2,9 +2,11 @@ source 'https://github.com/CocoaPods/Specs.git'
 
 platform :ios, '8.0'
 
+inhibit_all_warnings!
+
 target 'librato-iOS Demo' do
   pod 'librato-iOS', :path => '../librato-iOS.podspec'
-  
+
   target 'librato-iOS DemoTests' do
       inherit! :search_paths
   end

--- a/Demo/Podfile.lock
+++ b/Demo/Podfile.lock
@@ -1,0 +1,49 @@
+PODS:
+  - AFNetworking (2.6.3):
+    - AFNetworking/NSURLConnection (= 2.6.3)
+    - AFNetworking/NSURLSession (= 2.6.3)
+    - AFNetworking/Reachability (= 2.6.3)
+    - AFNetworking/Security (= 2.6.3)
+    - AFNetworking/Serialization (= 2.6.3)
+    - AFNetworking/UIKit (= 2.6.3)
+  - AFNetworking/NSURLConnection (2.6.3):
+    - AFNetworking/Reachability
+    - AFNetworking/Security
+    - AFNetworking/Serialization
+  - AFNetworking/NSURLSession (2.6.3):
+    - AFNetworking/Reachability
+    - AFNetworking/Security
+    - AFNetworking/Serialization
+  - AFNetworking/Reachability (2.6.3)
+  - AFNetworking/Security (2.6.3)
+  - AFNetworking/Serialization (2.6.3)
+  - AFNetworking/UIKit (2.6.3):
+    - AFNetworking/NSURLConnection
+    - AFNetworking/NSURLSession
+  - librato-iOS (1.2.2):
+    - AFNetworking (~> 2.0)
+    - Mantle (~> 1.3)
+  - Mantle (1.5.8):
+    - Mantle/extobjc (= 1.5.8)
+  - Mantle/extobjc (1.5.8)
+
+DEPENDENCIES:
+  - librato-iOS (from `../librato-iOS.podspec`)
+
+SPEC REPOS:
+  https://github.com/CocoaPods/Specs.git:
+    - AFNetworking
+    - Mantle
+
+EXTERNAL SOURCES:
+  librato-iOS:
+    :path: "../librato-iOS.podspec"
+
+SPEC CHECKSUMS:
+  AFNetworking: cb8d14a848e831097108418f5d49217339d4eb60
+  librato-iOS: ac4f9b431c771cccc0719e8bdade35648fac507d
+  Mantle: f03b2b606c3f0cabd80214ad8a2fed6b464a7359
+
+PODFILE CHECKSUM: 5817b13129eeec85d2fa75a097e506a23de0ee12
+
+COCOAPODS: 1.5.0

--- a/Demo/librato-iOS Demo.xcodeproj/project.pbxproj
+++ b/Demo/librato-iOS Demo.xcodeproj/project.pbxproj
@@ -193,7 +193,6 @@
 				66922617180358AF00237E77 /* Frameworks */,
 				66922618180358AF00237E77 /* Resources */,
 				CF311E2286F14B79A814F7BE /* [CP] Copy Pods Resources */,
-				49278725AA6A48415323BBF8 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -212,8 +211,6 @@
 				66922631180358AF00237E77 /* Sources */,
 				66922632180358AF00237E77 /* Frameworks */,
 				66922633180358AF00237E77 /* Resources */,
-				BAACFE891AE2BDA71802DAB9 /* [CP] Embed Pods Frameworks */,
-				B8F1461E083D696A5571BDE5 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -280,34 +277,22 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		49278725AA6A48415323BBF8 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-librato-iOS Demo/Pods-librato-iOS Demo-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
 		56571786C5174A36B0BB4AC8 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
 			);
 			name = "[CP] Check Pods Manifest.lock";
 			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-librato-iOS Demo-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
 		60F4CC329F21EB0D532804DC /* [CP] Check Pods Manifest.lock */ = {
@@ -316,43 +301,16 @@
 			files = (
 			);
 			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
 			);
 			name = "[CP] Check Pods Manifest.lock";
 			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-librato-iOS DemoTests-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
-			showEnvVarsInLog = 0;
-		};
-		B8F1461E083D696A5571BDE5 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-librato-iOS DemoTests/Pods-librato-iOS DemoTests-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		BAACFE891AE2BDA71802DAB9 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-librato-iOS DemoTests/Pods-librato-iOS DemoTests-frameworks.sh\"\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
 		CF311E2286F14B79A814F7BE /* [CP] Copy Pods Resources */ = {
@@ -361,9 +319,12 @@
 			files = (
 			);
 			inputPaths = (
+				"${SRCROOT}/Pods/Target Support Files/Pods-librato-iOS Demo/Pods-librato-iOS Demo-resources.sh",
+				"${PODS_ROOT}/../../librato-iOS/Librato-Localizable.strings",
 			);
 			name = "[CP] Copy Pods Resources";
 			outputPaths = (
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/Librato-Localizable.strings",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;


### PR DESCRIPTION
Since we don’t own third-party pods we shouldn’t have their warnings making noise in our project. So let’s ignore them.

I also made a change to stop ignoring `Podfile.lock`. Not sure why that was ever ignored.